### PR TITLE
Use `formatErrors` instead of `format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ To format errors when a `decode` or an `encode` function fails, you can use the 
 import * as S from "@fp-ts/schema/Schema";
 import * as P from "@fp-ts/schema/Parser";
 import * as PE from "@fp-ts/schema/ParseError";
-import { format } from "@fp-ts/schema/formatter/Tree";
+import { formatErrors } from "@fp-ts/schema/formatter/Tree";
 
 const Person = S.struct({
   name: S.string,
@@ -274,7 +274,7 @@ const Person = S.struct({
 const result = P.decode(Person)({});
 if (PE.isFailure(result)) {
   console.error("Decoding failed:");
-  console.error(format(result.left));
+  console.error(formatErrors(result.left));
 }
 /*
 Decoding failed:


### PR DESCRIPTION
While going through the examples, I found that `format` doesn't exist anymore and seems to have been renamed into `formatErrors`.

**Before submitting a pull request,** please make sure the following is done:

- Fork [the repository](https://github.com/gcanti/fp-ts) and create your branch from `master` (\*).
- Run `npm install` in the repository root.
- If you've fixed a bug or added code that should be tested, add tests!
- Ensure the test suite passes (`npm test`).

**Note**. If you've fixed a bug please link the related issue or, if missing, open an issue before sending a PR.

**Note**. If you find a typo in the **documentation**, make sure to modify the corresponding source (docs are generated).

(\*)

- if you want to send a PR related to `fp-ts@1.x` please create your branch from `1.x`
- if you want to send a PR related to `fp-ts@2.x` please create your branch from `2.x`
