### PR TITLE
feat: added data/Brand

### DIFF
--- a/.changeset/mighty-feet-warn.md
+++ b/.changeset/mighty-feet-warn.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/schema": patch
+---
+
+Add support for data/Brand

--- a/src/data/Brand.ts
+++ b/src/data/Brand.ts
@@ -1,0 +1,25 @@
+/**
+ * @since 1.0.0
+ */
+import * as B from "@fp-ts/data/Brand"
+import { pipe } from "@fp-ts/data/Function"
+import * as I from "@fp-ts/schema/internal/common"
+import type * as S from "@fp-ts/schema/Schema"
+
+/**
+ * @since 1.0.0
+ */
+export const brand = <C extends B.Brand<string>>(
+  constructor: B.Brand.Constructor<C>,
+  annotationOptions?: S.AnnotationOptions<B.Brand.Unbranded<C>>
+) =>
+  <A extends B.Brand.Unbranded<C>>(self: S.Schema<A>): S.Schema<A & C> =>
+    B.isNominal(constructor) ?
+      self as S.Schema<A & C> :
+      pipe(
+        self,
+        I.filter<A, A & C>(
+          (x): x is A & C => constructor.refine(x),
+          annotationOptions
+        )
+      )

--- a/test/data/Brand.ts
+++ b/test/data/Brand.ts
@@ -1,0 +1,41 @@
+import * as B from "@fp-ts/data/Brand"
+import { pipe } from "@fp-ts/data/Function"
+import * as _ from "@fp-ts/schema/data/Brand"
+import * as S from "@fp-ts/schema/Schema"
+import * as Util from "@fp-ts/schema/test/util"
+
+type Int = number & B.Brand<"Int">
+const Int = B.refined<Int>(
+  (n) => Number.isInteger(n),
+  (n) => B.error(`Expected ${n} to be an integer`)
+)
+
+type Positive = number & B.Brand<"Positive">
+const Positive = B.refined<Positive>(
+  (n) => n > 0,
+  (n) => B.error(`Expected ${n} to be positive`)
+)
+
+type PositiveInt = Positive & Int
+const PositiveInt = B.all(Int, Positive)
+
+type Eur = number & B.Brand<"Eur">
+const Eur = B.nominal<Eur>()
+
+describe.concurrent("Brand", () => {
+  it("property tests", () => {
+    Util.property(_.brand(Int)(S.number)) // refined
+    Util.property(_.brand(Eur)(S.number)) // nominal
+  })
+
+  it("refined", () => {
+    const schema = pipe(S.number, _.brand(Positive), _.brand(Int))
+
+    Util.expectDecodingFailure(schema, -0.5, "Expected refinement, actual -0.5")
+    Util.expectDecodingFailure(schema, -1, "Expected refinement, actual -1")
+    Util.expectDecodingFailure(schema, 0, "Expected refinement, actual 0")
+    Util.expectDecodingSuccess(schema, 1, 1 as PositiveInt)
+    Util.expectDecodingFailure(schema, 1.5, "Expected refinement, actual 1.5")
+    Util.expectDecodingSuccess(schema, 2, 2 as PositiveInt)
+  })
+})


### PR DESCRIPTION
Added data/Brand. Accepts either a `Brand` type or a `RefinedConstructors` to establish the brand. In the first case the brand is simply attached at the type level and in the latter case the value is tested against the `RefinedConstructors.refine` function before the brand is attached. 