### PR TITLE
Update README to reflect removal of `transform` from ParseError

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ import { pipe } from "@fp-ts/data/Function";
 import * as PE from "@fp-ts/schema/ParseError";
 import type { ParseResult } from "@fp-ts/schema/ParseError";
 import * as S from "@fp-ts/schema/Schema";
+import * as AST from "@fp-ts/schema/AST";
 
 // define a schema for the string type
 const stringSchema: S.Schema<string> = S.string;
@@ -892,7 +893,7 @@ const decode = (s: string): ParseResult<boolean> =>
     ? PE.success(true)
     : s === "false"
     ? PE.success(false)
-    : PE.failure(PE.transform("string", "boolean", s));
+    : PE.failure(PE.type(AST.stringKeyword, s));
 
 // define a function that converts a boolean into a string
 const encode = (b: boolean): ParseResult<string> => PE.success(String(b));

--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ const decode = (s: string): ParseResult<boolean> =>
     ? PE.success(true)
     : s === "false"
     ? PE.success(false)
-    : PE.failure(PE.type(AST.stringKeyword, s));
+    : PE.failure(PE.type(AST.union([AST.literal('true'), AST.literal('false')]), s));
 
 // define a function that converts a boolean into a string
 const encode = (b: boolean): ParseResult<string> => PE.success(String(b));

--- a/README.md
+++ b/README.md
@@ -877,7 +877,7 @@ Here's an example of the `transformOrFail` combinator which converts a `string` 
 ```ts
 import { pipe } from "@fp-ts/data/Function";
 import * as PE from "@fp-ts/schema/ParseError";
-import type { ParseResult } from "@fp-ts/schema/Parser";
+import type { ParseResult } from "@fp-ts/schema/ParseError";
 import * as S from "@fp-ts/schema/Schema";
 
 // define a schema for the string type


### PR DESCRIPTION
The following commit removed `transform` from the ParseError module:
https://github.com/fp-ts/schema/commit/27e54bb031df7fda429f8a6d3e56ac87484a96a7

