### PR TITLE
fix: extend union with mutually exclusive properties

### DIFF
--- a/test/Arbitrary.ts
+++ b/test/Arbitrary.ts
@@ -328,4 +328,17 @@ describe.concurrent("Arbitrary", () => {
     const schema = pipe(S.number, S.finite())
     property(schema)
   })
+
+  it("extend with union containing overlapping fields", () => {
+    const schema = pipe(
+      S.struct({ a: S.literal("a") }),
+      S.extend(
+        S.union(
+          S.struct({ a: S.literal("b"), b: S.string }),
+          S.struct({ a: S.literal("a"), b: S.number })
+        )
+      )
+    )
+    property(schema)
+  })
 })

--- a/test/Schema.ts
+++ b/test/Schema.ts
@@ -298,5 +298,30 @@ describe.concurrent("Schema", () => {
       expect(is({ c: false })).toBe(false)
       expect(is({ d: 42 })).toBe(false)
     })
+
+    it(`extend struct by union with mutually exclusive properties`, () => {
+      const schema1 = pipe(
+        S.struct({ a: S.literal("a") }),
+        S.extend(
+          S.union(
+            S.struct({ a: S.literal("a"), b: S.string }),
+            S.struct({ a: S.literal("b"), b: S.number })
+          )
+        )
+      )
+
+      const schema2 = pipe(
+        S.union(
+          S.struct({ a: S.literal("a"), b: S.string }),
+          S.struct({ a: S.literal("b"), b: S.number })
+        ),
+        S.extend(S.struct({ a: S.literal("a") }))
+      )
+
+      const equivalentSchema = S.struct({ a: S.literal("a"), b: S.string })
+
+      expect(schema1).toStrictEqual(equivalentSchema)
+      expect(schema2).toStrictEqual(equivalentSchema)
+    })
   })
 })


### PR DESCRIPTION
Hey,

after [adding the support for union types](https://github.com/fp-ts/schema/pull/34), the `extend` allows the following construction

```typescript
pipe(
  S.struct({ a: S.literal("a") }),
  S.extend(
    S.union(
      S.struct({ a: S.literal("b"), b: S.string }),
      S.struct({ a: S.literal("a"), b: S.number })
    )
  )
)
```

which has an expected type

```typescript
S.Schema<{
  readonly a: "a";
  readonly b: number;
}>
```

but in the term-level code the AST is a union where each element has a duplicated `a` literal. As a consequence, fast-check generates a non-sensical object `{"a":"b","b":""}`.

One solution is simply not supporting overlapping properties for the `extend` combinator but I find it super useful to be able to extend with an union where each element can discriminate with its field.

Therefore, in this MR I'm proposing to move the implentation of `extend` closer to what `Spread` does in the type-level code. I added more general `intersectTypeLiterals` function which returns `Option<AST.TypeLiteral>` to be able to skip mutually exclusive combinations of `TypeLiteral`s. It uses `areMutuallyExclusive` function which currently supports only `Literal`s but I can imagine it could be implemented for other AST variants. 

*Side-note: I'm currently in a process of an experimental rewrite from `io-ts` in our project and this is the last bit I was missing to have a successful prototype. That's why I focused on the `TypeLiteral` only.*

A similar issue happens for the following schema

```typescript
pipe(
  S.struct({ a: S.struct({ b: S.string }) }),
  S.extend(
    S.struct({ a: S.struct({ b: S.string, c: S.number }) }),
  )
)

// --> type
S.Schema<{
  readonly a: {
    readonly b: string;
  } & {
    readonly b: string;
    readonly c: number;
  };
}>
```

for which `P.is(schema)` works incorrectly / unexpectedly. The `areMutuallyExclusive` can catch it and at least it fails immediately which is probably better than having unexpected behaviour on derived artifacts. I suppose, it will be necessary to implement a general AST intersection that behaves the same way as the type intersection in the future.

@gcanti, please let me know what you think. 

And thank you for your awesome work on this and all the other projects. `@fp-ts/schema` feels like it's gonna be a game changer!