### PR TITLE
fix: encoder refinement

### DIFF
--- a/test/Encoder.ts
+++ b/test/Encoder.ts
@@ -491,4 +491,9 @@ describe.concurrent("Encoder", () => {
       allErrors
     )
   })
+
+  it("encode parsed number with refinement", () => {
+    const schema = pipe(P.parseNumber(S.string), S.int())
+    Util.expectEncodingSuccess(schema, 1, "1")
+  })
 })


### PR DESCRIPTION
Hey, during implementation of a schema for an integer parsed from a string (running a refinement on top of a transformation) I noticed the encoder returns a failure unexpectedly. Here's my example schema.

```typescript
pipe(P.parseNumber(S.string), S.int())
```

The problem seems to be in the `Refinement` implementation. It runs the refinement check after running parsing on the `ast.from`. I think for the `encoder` case it should be the other way around and it looks like it fixed the issue.