### PR TITLE
Remove json primitive in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,6 @@ S.bigint;
 S.boolean;
 S.symbol;
 S.object;
-S.json;
 S.date; // value must be a Date
 
 // empty types


### PR DESCRIPTION
It looks like `S.json` was removed in this PR: https://github.com/fp-ts/schema/pull/68

...but it is still referenced as a primitive in the README. Removing as it is no longer exported.
