### PR TITLE
feat: added data/Bigint and N.between

### DIFF
--- a/.changeset/empty-ducks-kick.md
+++ b/.changeset/empty-ducks-kick.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/schema": patch
+---
+
+added data/Bigint and between filters for Number

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ pipe(S.number, S.greaterThan(5));
 pipe(S.number, S.greaterThanOrEqualTo(5));
 pipe(S.number, S.lessThan(5));
 pipe(S.number, S.lessThanOrEqualTo(5));
+pipe(S.number, S.between(-2, 2)); // -2 <= x <= 2
 
 pipe(S.number, S.int()); // value must be an integer
 
@@ -483,12 +484,29 @@ pipe(S.number, S.negative()); // < 0
 pipe(S.number, S.nonPositive()); // <= 0
 ```
 
+### Bigint filters
+
+```ts
+import * as B from "@fp-ts/schema/data/Bigint";
+
+pipe(S.bigint, B.greaterThan(5n));
+pipe(S.bigint, B.greaterThanOrEqualTo(5n));
+pipe(S.bigint, B.lessThan(5n));
+pipe(S.bigint, B.lessThanOrEqualTo(5n));
+pipe(S.bigint, B.between(-2n, 2n)); // -2n <= x <= 2n
+
+pipe(S.bigint, B.positive()); // > 0n
+pipe(S.bigint, B.nonNegative()); // >= 0n
+pipe(S.bigint, B.negative()); // < 0n
+pipe(S.bigint, B.nonPositive()); // <= 0n
+```
+
 ### Array filters
 
 ```ts
-pipe(S.array(S.number), A.maxItems(2)) // max array length
-pipe(S.array(S.number), A.minItems(2)) // min array length
-pipe(S.array(S.number), A.itemsCount(2)) // exact array length
+pipe(S.array(S.number), A.maxItems(2)); // max array length
+pipe(S.array(S.number), A.minItems(2)); // min array length
+pipe(S.array(S.number), A.itemsCount(2)); // exact array length
 ```
 
 ## Native enums

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -278,6 +278,16 @@ export const greaterThanOrEqualTo: <A extends number>(
  * @category filters
  * @since 1.0.0
  */
+export const between: <A extends number>(
+  min: number,
+  max: number,
+  annotationOptions?: AnnotationOptions<A>
+) => (self: Schema<A>) => Schema<A> = N.between
+
+/**
+ * @category filters
+ * @since 1.0.0
+ */
 export const int: <A extends number>(
   annotationOptions?: AnnotationOptions<A>
 ) => (self: Schema<A>) => Schema<A> = N.int

--- a/src/data/Bigint.ts
+++ b/src/data/Bigint.ts
@@ -1,0 +1,138 @@
+/**
+ * @since 1.0.0
+ */
+
+import { pipe } from "@fp-ts/core/Function"
+import * as I from "@fp-ts/schema/internal/common"
+import type { AnnotationOptions, Schema } from "@fp-ts/schema/Schema"
+
+/**
+ * @since 1.0.0
+ */
+export const greaterThan = <A extends bigint>(
+  min: bigint,
+  annotationOptions?: AnnotationOptions<A>
+) =>
+  (self: Schema<A>): Schema<A> =>
+    pipe(
+      self,
+      I.filter((a): a is A => a > min, {
+        description: `a bigint greater than ${min}`,
+        jsonSchema: { exclusiveMinimum: min },
+        ...annotationOptions
+      })
+    )
+
+/**
+ * @since 1.0.0
+ */
+export const greaterThanOrEqualTo = <A extends bigint>(
+  min: bigint,
+  annotationOptions?: AnnotationOptions<A>
+) =>
+  (self: Schema<A>): Schema<A> =>
+    pipe(
+      self,
+      I.filter((a): a is A => a >= min, {
+        description: `a bigint greater than or equal to ${min}`,
+        jsonSchema: { minimum: min },
+        ...annotationOptions
+      })
+    )
+
+/**
+ * @since 1.0.0
+ */
+export const lessThan = <A extends bigint>(max: bigint, annotationOptions?: AnnotationOptions<A>) =>
+  (self: Schema<A>): Schema<A> =>
+    pipe(
+      self,
+      I.filter((a): a is A => a < max, {
+        description: `a bigint less than ${max}`,
+        jsonSchema: { exclusiveMaximum: max },
+        ...annotationOptions
+      })
+    )
+
+/**
+ * @since 1.0.0
+ */
+export const lessThanOrEqualTo = <A extends bigint>(
+  max: bigint,
+  annotationOptions?: AnnotationOptions<A>
+) =>
+  (self: Schema<A>): Schema<A> =>
+    pipe(
+      self,
+      I.filter((a): a is A => a <= max, {
+        description: `a bigint less than or equal to ${max}`,
+        jsonSchema: { maximum: max },
+        ...annotationOptions
+      })
+    )
+
+/**
+ * @since 1.0.0
+ */
+export const between = <A extends bigint>(
+  min: bigint,
+  max: bigint,
+  annotationOptions?: AnnotationOptions<A>
+) =>
+  (self: Schema<A>): Schema<A> =>
+    pipe(
+      self,
+      I.filter((a): a is A => a >= min && a <= max, {
+        description: `a bigint between ${min} and ${max}`,
+        jsonSchema: { maximum: max, minimum: max },
+        ...annotationOptions
+      })
+    )
+
+/**
+ * @since 1.0.0
+ */
+export const positive = <A extends bigint>(
+  annotationOptions?: AnnotationOptions<A>
+): (self: Schema<A>) => Schema<A> =>
+  greaterThan(0n, {
+    description: "a positive bigint",
+    custom: { type: "positive" },
+    ...annotationOptions
+  })
+
+/**
+ * @since 1.0.0
+ */
+export const negative = <A extends bigint>(
+  annotationOptions?: AnnotationOptions<A>
+): (self: Schema<A>) => Schema<A> =>
+  lessThan(0n, {
+    description: "a negative bigint",
+    custom: { type: "negative" },
+    ...annotationOptions
+  })
+
+/**
+ * @since 1.0.0
+ */
+export const nonNegative = <A extends bigint>(
+  annotationOptions?: AnnotationOptions<A>
+): (self: Schema<A>) => Schema<A> =>
+  greaterThanOrEqualTo(0n, {
+    description: "a non-negative bigint",
+    custom: { type: "nonNegative" },
+    ...annotationOptions
+  })
+
+/**
+ * @since 1.0.0
+ */
+export const nonPositive = <A extends bigint>(
+  annotationOptions?: AnnotationOptions<A>
+): (self: Schema<A>) => Schema<A> =>
+  lessThanOrEqualTo(0n, {
+    description: "a non-positive bigint",
+    custom: { type: "nonPositive" },
+    ...annotationOptions
+  })

--- a/test/data/Bigint.ts
+++ b/test/data/Bigint.ts
@@ -1,0 +1,83 @@
+import { pipe } from "@fp-ts/core/Function"
+import * as B from "@fp-ts/schema/data/Bigint"
+import * as S from "@fp-ts/schema/Schema"
+import * as Util from "@fp-ts/schema/test/util"
+
+describe.concurrent("Bigint", () => {
+  it("greaterThan", () => {
+    const schema = pipe(S.bigint, B.greaterThan(0n))
+
+    Util.expectDecodingFailure(schema, -1n, "Expected a bigint greater than 0, actual -1")
+    Util.expectDecodingFailure(schema, 0n, "Expected a bigint greater than 0, actual 0")
+    Util.expectEncodingSuccess(schema, 1n, 1n)
+  })
+
+  it("greaterThanOrEqualTo", () => {
+    const schema = pipe(S.bigint, B.greaterThanOrEqualTo(0n))
+
+    Util.expectDecodingFailure(
+      schema,
+      -1n,
+      "Expected a bigint greater than or equal to 0, actual -1"
+    )
+    Util.expectDecodingSuccess(schema, 0n, 0n)
+    Util.expectEncodingSuccess(schema, 1n, 1n)
+  })
+
+  it("lessThan", () => {
+    const schema = pipe(S.bigint, B.lessThan(0n))
+
+    Util.expectEncodingSuccess(schema, -1n, -1n)
+    Util.expectDecodingFailure(schema, 0n, "Expected a bigint less than 0, actual 0")
+    Util.expectDecodingFailure(schema, 1n, "Expected a bigint less than 0, actual 1")
+  })
+
+  it("lessThanOrEqualTo", () => {
+    const schema = pipe(S.bigint, B.lessThanOrEqualTo(0n))
+
+    Util.expectEncodingSuccess(schema, -1n, -1n)
+    Util.expectDecodingSuccess(schema, 0n, 0n)
+    Util.expectDecodingFailure(schema, 1n, "Expected a bigint less than or equal to 0, actual 1")
+  })
+
+  it("between", () => {
+    const schema = pipe(S.bigint, B.between(-1n, 1n))
+
+    Util.expectDecodingFailure(schema, -2n, "Expected a bigint between -1 and 1, actual -2")
+    Util.expectDecodingSuccess(schema, 0n, 0n)
+    Util.expectEncodingSuccess(schema, 1n, 1n)
+    Util.expectDecodingFailure(schema, 2n, "Expected a bigint between -1 and 1, actual 2")
+  })
+
+  it("positive", () => {
+    const schema = pipe(S.bigint, B.positive())
+
+    Util.expectDecodingFailure(schema, -1n, "Expected a positive bigint, actual -1")
+    Util.expectDecodingFailure(schema, 0n, "Expected a positive bigint, actual 0")
+    Util.expectEncodingSuccess(schema, 1n, 1n)
+  })
+
+  it("negative", () => {
+    const schema = pipe(S.bigint, B.negative())
+
+    Util.expectEncodingSuccess(schema, -1n, -1n)
+    Util.expectDecodingFailure(schema, 0n, "Expected a negative bigint, actual 0")
+    Util.expectDecodingFailure(schema, 1n, "Expected a negative bigint, actual 1")
+  })
+
+  it("nonNegative", () => {
+    const schema = pipe(S.bigint, B.nonNegative())
+
+    Util.expectEncodingFailure(schema, -1n, "Expected a non-negative bigint, actual -1")
+    Util.expectDecodingSuccess(schema, 0n, 0n)
+    Util.expectDecodingSuccess(schema, 1n, 1n)
+  })
+
+  it("nonPositive", () => {
+    const schema = pipe(S.bigint, B.nonPositive())
+
+    Util.expectEncodingSuccess(schema, -1n, -1n)
+    Util.expectDecodingSuccess(schema, 0n, 0n)
+    Util.expectDecodingFailure(schema, 1n, "Expected a non-positive bigint, actual 1")
+  })
+})

--- a/test/data/Number.ts
+++ b/test/data/Number.ts
@@ -4,6 +4,15 @@ import * as S from "@fp-ts/schema/Schema"
 import * as Util from "@fp-ts/schema/test/util"
 
 describe.concurrent("Number", () => {
+  it("between", () => {
+    const schema = pipe(S.number, N.between(-1, 1))
+
+    Util.expectDecodingFailure(schema, -2, "Expected a number between -1 and 1, actual -2")
+    Util.expectDecodingSuccess(schema, 0, 0)
+    Util.expectEncodingSuccess(schema, 1, 1)
+    Util.expectDecodingFailure(schema, 2, "Expected a number between -1 and 1, actual 2")
+  })
+
   it("positive", () => {
     const schema = pipe(S.number, N.positive())
 


### PR DESCRIPTION
Duplicated the functionality of data/Number to data/Bigint and added between and betweenExclusive filters for both modules. Using data/Bigint must be namespaced due to name collisions with number. 