### PR TITLE
fix: enhance union unification for boolean and bigint literals

### DIFF
--- a/src/AST.ts
+++ b/src/AST.ts
@@ -305,6 +305,12 @@ export const booleanKeyword: BooleanKeyword = {
 }
 
 /**
+ * @category guards
+ * @since 1.0.0
+ */
+export const isBooleanKeyword = (ast: AST): ast is BooleanKeyword => ast._tag === "BooleanKeyword"
+
+/**
  * @category model
  * @since 1.0.0
  */
@@ -322,6 +328,12 @@ export const bigIntKeyword: BigIntKeyword = {
     [TitleId]: "bigint"
   }
 }
+
+/**
+ * @category guards
+ * @since 1.0.0
+ */
+export const isBigIntKeyword = (ast: AST): ast is BigIntKeyword => ast._tag === "BigIntKeyword"
 
 /**
  * @category model
@@ -945,6 +957,12 @@ const unify = (candidates: ReadonlyArray<AST>): ReadonlyArray<AST> => {
   }
   if (out.some(isNumberKeyword)) {
     out = out.filter((m) => !(isLiteral(m) && typeof m.literal === "number"))
+  }
+  if (out.some(isBooleanKeyword)) {
+    out = out.filter((m) => !(isLiteral(m) && typeof m.literal === "boolean"))
+  }
+  if (out.some(isBigIntKeyword)) {
+    out = out.filter((m) => !(isLiteral(m) && typeof m.literal === "bigint"))
   }
   if (out.some(isSymbolKeyword)) {
     out = out.filter((m) => !isUniqueSymbol(m))

--- a/test/AST.ts
+++ b/test/AST.ts
@@ -107,6 +107,14 @@ describe.concurrent("AST", () => {
     expect(S.union(S.literal(1), S.number).ast).toEqual(S.number.ast)
   })
 
+  it("union/ should unify boolean literals with boolean", () => {
+    expect(S.union(S.literal(true), S.boolean).ast).toEqual(S.boolean.ast)
+  })
+
+  it("union/ should unify bigint literals with bigint", () => {
+    expect(S.union(S.literal(1n), S.bigint).ast).toEqual(S.bigint.ast)
+  })
+
   it("union/ should unify symbol literals with symbol", () => {
     expect(S.union(S.uniqueSymbol(Symbol.for("@fp-ts/schema/test/a")), S.symbol).ast).toEqual(
       S.symbol.ast


### PR DESCRIPTION
It correctly unify the union of a boolean literal with the `boolean` primitive, and the union of a bigint with the `bigint` one.