### PR TITLE
fix: removed incorrect description for S.date

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -859,9 +859,7 @@ export const symbol: Schema<symbol> = I.symbol
 export const object: Schema<object> = I.object
 
 /**
- * Transforms a `string` into a `string` with no leading or trailing whitespace.
- *
- * @category data
+ * @category primitives
  * @since 1.0.0
  */
 export const date: Schema<Date> = DataDate.date


### PR DESCRIPTION
The description for S.date is incorrect. 

<img width="493" alt="Screen Shot 2023-02-23 at 1 33 11 PM" src="https://user-images.githubusercontent.com/22938931/220906816-b60b4728-a614-4772-b358-89131a485785.png">
